### PR TITLE
Fix daily profit calculation precision loss

### DIFF
--- a/src/main/kotlin/com/vermouthx/stocker/utils/StockerQuoteParser.kt
+++ b/src/main/kotlin/com/vermouthx/stocker/utils/StockerQuoteParser.kt
@@ -38,7 +38,7 @@ object StockerQuoteParser {
                     val current = textArray[4].toDouble()
                     val high = textArray[5].toDouble()
                     val low = textArray[6].toDouble()
-                    val change = (current - close).twoDigits()
+                    val change = current - close
                     val percentage = ((current - close) / close * 100).twoDigits()
                     val updateAt = textArray[31] + " " + textArray[32]
                     StockerQuote(
@@ -63,7 +63,7 @@ object StockerQuoteParser {
                     val high = textArray[5].toDouble()
                     val low = textArray[6].toDouble()
                     val current = textArray[7].toDouble()
-                    val change = (current - close).twoDigits()
+                    val change = current - close
                     val percentage = textArray[9].toDouble().twoDigits()
                     val sourceFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")
                     val targetFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
@@ -92,7 +92,7 @@ object StockerQuoteParser {
                     val high = textArray[7].toDouble()
                     val low = textArray[8].toDouble()
                     val close = textArray[27].toDouble()
-                    val change = (current - close).twoDigits()
+                    val change = current - close
                     val percentage = textArray[3].toDouble().twoDigits()
                     StockerQuote(
                         code = code,
@@ -115,7 +115,7 @@ object StockerQuoteParser {
                     val low = textArray[8].toDouble()
                     val high = textArray[7].toDouble()
                     val opening = textArray[6].toDouble()
-                    val change = (current - opening).twoDigits()
+                    val change = current - opening
                     val percentage = ((current - opening) / opening * 100).twoDigits()
                     val updateAt = "${textArray[12]} ${textArray[1]}"
                     StockerQuote(
@@ -153,7 +153,7 @@ object StockerQuoteParser {
             val current = textArray[4].toDouble()
             val high = textArray[34].toDouble()
             val low = textArray[35].toDouble()
-            val change = (current - close).twoDigits()
+            val change = current - close
             val percentage = textArray[33].toDouble().twoDigits()
             val updateAt = when (marketType) {
                 StockerMarketType.AShare -> {


### PR DESCRIPTION
What does this PR do? This PR fixes a severe precision loss issue in the "Daily Profit" (当日盈亏) calculation.

Why is this change necessary? Previously, in StockerQuoteParser.kt, the quote's price change was forcefully rounded to 2 decimal places using .twoDigits() immediately after parsing. However, in StockerQuoteUpdateListener and StockerTableView, the daily profit is calculated as change * holdings. Because the rounding occurred before the multiplication, the lost precision (e.g. 0.004 rounded to 0.00) was amplified by the holdings amount, leading to highly inaccurate daily profit values. This was especially problematic for cryptocurrencies (like DOGE or SHIB) where price changes are extremely small, causing the daily profit to always display as 0.000.

How was it fixed?

Removed .twoDigits() from the change variable in StockerQuoteParser.kt across all market types (AShare, HKStocks, USStocks, Crypto).
The raw Double precision is now preserved for the change * holdings multiplication.
No changes were needed for the UI, as ChangeCellRenderer and DailyProfitCellRenderer already handle formatting values to the correct decimal places gracefully for the table display.